### PR TITLE
Fix PIL for Python 3.13.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -46,3 +46,4 @@ build_im
 build_pillow
 build_filigree_cpp
 build_filigree_python
+pytest filigree

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$CONDA_PREFIX/lib/pkgconfig
+set -euo pipefail
+
+export PKG_CONFIG_PATH=${PKG_CONFIG_PATH:-}:$CONDA_PREFIX/lib/pkgconfig
 
 build_im()
 {

--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,7 @@ export PKG_CONFIG_PATH=${PKG_CONFIG_PATH:-}:$CONDA_PREFIX/lib/pkgconfig
 build_im()
 {
   echo "Building ImageMagick..."
+  rm -rf im_build
   mkdir im_build
   cd im_build
   ../vendor/ImageMagick6/configure --prefix=$CONDA_PREFIX
@@ -26,6 +27,7 @@ build_pillow()
 build_filigree_cpp()
 {
   echo "Building Filigree C++ components..."
+  rm -rf build
   mkdir build
   cd build
   cmake .. -G Ninja -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX

--- a/vendor/Pillow/setup.py
+++ b/vendor/Pillow/setup.py
@@ -21,9 +21,10 @@ from setuptools.command.build_ext import build_ext
 
 def get_version():
     version_file = "src/PIL/_version.py"
+    context = {}
     with open(version_file) as f:
-        exec(compile(f.read(), version_file, "exec"))
-    return locals()["__version__"]
+        exec(compile(f.read(), version_file, "exec"), context)
+    return context["__version__"]
 
 
 PILLOW_VERSION = get_version()


### PR DESCRIPTION
Creating a new mamba environment per the `README.md` instructions now picks up Python 3.13, which requires the following fix to `vendor/Pillow/setup.py`.

Also, tweak the `build.sh` to make build failures more obvious.  Without these changes, there's no obvious indication the build failed at the end of the script's invocation... so the failure to import `PIL` is all the more perplexing.